### PR TITLE
`.zshrc`にカスタムバイナリパスを追加し、不要な環境初期化コードを削除する

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -51,17 +51,13 @@ export CPLUS_INCLUDE_PATH="${CPLUS_INCLUDE_PATH}:~/.ghq/github.com/atcoder/ac-li
 export CPATH=${CPATH}:~/.ghq/github.com/atcoder/ac-library
 export DENO_INSTALL="/home/fumi/.deno"
 export PATH="$DENO_INSTALL/bin:$PATH"
+export PATH="$HOME/.local/mybin:$PATH"
 
 which starship > /dev/null && eval "$(starship init zsh)"
 which direnv > /dev/null && eval "$(direnv hook zsh)"
 which kubectl > /dev/null && source <(kubectl completion zsh)
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
 [ -f ~/.zsh/scripts/pipr_hotkey.zsh ] && source ~/.zsh/scripts/pipr_hotkey.zsh
-eval "$(anyenv init -)"
-source "$HOME/.rye/env"
-
-#eval "$(gh completion -s zsh)"
-#eval "$(rbenv init -)"
 
 # disable <C-s> and <C-q>
 if [[ -t 0 ]]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shell PATH to include a custom per-user binary directory.
  * Removed initialization of development environment tools from shell startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->