### PR TITLE
`.tigrcのaicommitバインドをAに変更しMでクイックコミットを追加し、zshrcにviモードの^oでedit-command-…

### DIFF
--- a/.tigrc
+++ b/.tigrc
@@ -122,8 +122,11 @@ bind main    H      ?git reset --hard %(commit)
 bind diff    H      ?git reset --hard %(commit)
 bind refs    H      ?git reset --hard %(branch)
 
-# H で aicommit (status-view)
+# A で aicommit (status-view)
 bind status  A      !git aicommit
+
+# M で aicommit (status-view)
+bind status  M      !git commit -m "update"
 
 # H で reset --hard HEAD (status-view)
 bind status  H      ?git reset --hard HEAD

--- a/.tigrc
+++ b/.tigrc
@@ -125,7 +125,7 @@ bind refs    H      ?git reset --hard %(branch)
 # A で aicommit (status-view)
 bind status  A      !git aicommit
 
-# M で aicommit (status-view)
+# M で シンプルなcommit (status-view)
 bind status  M      !git commit -m "update"
 
 # H で reset --hard HEAD (status-view)

--- a/.zshrc
+++ b/.zshrc
@@ -11,6 +11,7 @@ eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 autoload -Uz compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
 autoload -U edit-command-line
+zle -N edit-command-line
 
 #export DOCKER_HOST=tcp://localhost:2375
 export BAT_THEME='Solarized (light)'
@@ -497,7 +498,6 @@ bindkey -a ds delete-surround
 bindkey -a ys add-surround
 bindkey -M visual S add-surround
 
-zle -N edit-command-line
 bindkey '^o' edit-command-line
 
 [ -f ~/.local/.zshrc ] && source ~/.local/.zshrc

--- a/.zshrc
+++ b/.zshrc
@@ -470,6 +470,7 @@ bindkey -M viins '^v^t' ffiles
 
 bindkey -M vicmd 'g' peco-src
 bindkey -M vicmd 'r' fzf-history-widget
+bindkey -M vicmd '^o' edit-command-line
 
 autoload -U select-bracketed
 zle -N select-bracketed


### PR DESCRIPTION
…lineを登録する`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quick commit keybinding (press M) that creates a commit with a default message.
  * Added shell command editing keybinding (Ctrl+O) in vi normal mode for faster command edits.

* **Chores**
  * Clarified and reassigned status-view keybindings (A for AI-commit, H remains hard-reset) for clearer workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->